### PR TITLE
Fixing Issue #6 of teastman branch (Connection not closed)

### DIFF
--- a/ftp-download.js
+++ b/ftp-download.js
@@ -44,7 +44,6 @@ module.exports = function (RED) {
     function FtpDownloadNode(n) {
         RED.nodes.createNode(this, n);
 
-        const conn = new ftp();
         const flow = this.context().flow;
         const global = this.context().global;
         const node = this;
@@ -60,7 +59,8 @@ module.exports = function (RED) {
         let directory = "";
 
         node.on('input', (msg) => {
-
+            const conn = new ftp();
+            
             // Load the files list from the appropriate variable.
             try {
                 switch (node.filesType) {
@@ -121,6 +121,7 @@ module.exports = function (RED) {
                 promise
                     .then((filePaths)=> {
                         msg[node.output] = filePaths;
+                        conn.end();
                         node.send(msg);
                     })
                     .catch((err) => {
@@ -185,7 +186,8 @@ module.exports = function (RED) {
 
         node.on('close', () => {
             try {
-                conn.destroy();
+                // conn.destroy();
+                // Line removed since connection should be already closed
             }
             catch (err) {
                 // Do nothing as the node is closed anyway.


### PR DESCRIPTION
Fixing Issue #6 of teastman branch (https://github.com/teastman/node-red-contrib-ftp-download/issues/6)
"Connection not closed"
Subsequent connections were left opened, and timeout messages occurred.

Node feeded every 240 seconds through an inject node produced:
0:00:04 - msg.payload out (ok)
0:02:04 - FTP timeout message (!!!)
0:04:04 - msg.payload out (ok)
0:04:04 - msg.payload out (again!)
0:06:04 - FTP timeout message (!!!)
0:06:04 - FTP timeout message (!!!)
0:08:04 - msg.payload out
0:08:04 - msg.payload out (again!)
0:08:04 - msg.payload out (again!)
0:10:04 - FTP timeout message (!!!)
0:10:04 - FTP timeout message (!!!)
0:10:04 - FTP timeout message (!!!)
...and so on.

This edit should fix these problems.